### PR TITLE
Bump version snippets to 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ SDKs, cross toolchains or system packages to install on the build machine.
    ```xml
    <Project Sdk="Microsoft.NET.Sdk">
 
-     <Sdk Name="StuDev.AotAnywhere" Version="1.0.4" />
+     <Sdk Name="StuDev.AotAnywhere" Version="1.0.5" />
    ```
 
    (Or omit the `Version` and pin it once in `global.json` under

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,7 +2,7 @@
 // AotAnywhere — single-page site.
 // Ported from the "blueprint / technical" design direction (Claude Design),
 // with canvas chrome removed and the template placeholders wired to real values.
-const version = '1.0.4';
+const version = '1.0.5';
 const githubUrl = 'https://github.com/slang25/AotAnywhere';
 const nugetUrl = 'https://www.nuget.org/packages/StuDev.AotAnywhere';
 


### PR DESCRIPTION
Prep for the 1.0.5 release: bump the Quick start `Sdk` version snippet (README) and the site's `version` const from 1.0.4 to 1.0.5.

Headline change since 1.0.4 is #94 — the macOS zig link fix, where binaries died on their first garbage collection.

After merge, dispatch `publish.yml` with version=1.0.5 to pack → publish to nuget.org and create the `v1.0.5` tag + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)