### PR TITLE
Apply the macOS exports list ourselves, zig ignores it

### DIFF
--- a/.github/scripts/build-targets.sh
+++ b/.github/scripts/build-targets.sh
@@ -57,7 +57,9 @@ for target in "${TARGET_ARRAY[@]}"; do
   # Pseudo-target decorations select publish variants of the same RID; the
   # artifact directory keeps the decorated name so the validate job can
   # exercise each variant:
-  #   lib-<rid>      - test/HelloLib, a NativeLib=Shared library
+  #   lib-<rid>      - test/HelloLib, a NativeLib=Shared library (Linux
+  #                    and macOS; the dylib proves the exports list is
+  #                    applied on a zig macho link, issue #98)
   #   <rid>-selftest - Hello with AotAnywhereSelfTest=true: net10.0 and real
   #                    ICU (no InvariantGlobalization), zlib and OpenSSL
   #                    exercised at run time via --selftest
@@ -117,9 +119,10 @@ for target in "${TARGET_ARRAY[@]}"; do
     # For macOS targets, use AotAnywhere for cross-compilation.
     # Deliberately no StripSymbols override: it defaults to true and is
     # honoured at link time via ld64's -x/-S (issue #62); the mac runners
-    # assert the local symbols are actually gone.
-    if dotnet publish test/Hello.csproj \
-      -r "$target" \
+    # assert the local symbols are actually gone, and that the exports
+    # list was applied (issue #98).
+    if dotnet publish "$project" \
+      -r "$rid" \
       -c Release \
       -p:InvariantGlobalization=true \
       -p:BaseIntermediateOutputPath="$obj_dir" \
@@ -160,6 +163,7 @@ for target in "${TARGET_ARRAY[@]}"; do
     binary_name="$binary_base"
     [[ "$rid" == win-* ]] && binary_name="$binary_base.exe"
     [[ "$rid" == linux-* && "$binary_base" == "HelloLib" ]] && binary_name="$binary_base.so"
+    [[ "$rid" == osx-* && "$binary_base" == "HelloLib" ]] && binary_name="$binary_base.dylib"
 
     if [ -f "artifacts/$host_name/$target/$binary_name" ]; then
       echo "✅ Binary confirmed: $binary_name for $target"

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -460,8 +460,8 @@ jobs:
                 # The publish must have stripped local symbols and stabs at
                 # link time (ld64 -x/-S, issue #62): unstripped output carries
                 # tens of thousands of ILC locals + stabs, stripped output a
-                # couple hundred zig-synthesized thunks. Externals don't count
-                # - ILC 8 emits ~14k that link-time stripping cannot remove.
+                # couple hundred zig-synthesized thunks. Externals are checked
+                # separately below.
                 echo -n "  Strip check: "
                 local_count=$(nm -a "$binary_path" 2>/dev/null | awk '$2 == "-" || $2 ~ /^[a-z]$/' | wc -l | tr -d ' ')
                 if [ "$local_count" -ge 5000 ]; then
@@ -469,6 +469,20 @@ jobs:
                   continue
                 fi
                 echo "✅ stripped ($local_count local symbols)"
+
+                # The exports list must have been applied (issue #98): zig
+                # ignores -exported_symbols_list, so AotAnywherePatchAppleObject
+                # demotes every ILC external not on the list before the link.
+                # Unapplied, ILC 8 leaves ~14k managed method symbols exported;
+                # applied, only the runtime's static-library externals (a few
+                # hundred) remain.
+                echo -n "  Exports check: "
+                export_count=$(nm -gU "$binary_path" 2>/dev/null | wc -l | tr -d ' ')
+                if [ "$export_count" -ge 2000 ]; then
+                  echo "❌ FAIL - $export_count exported symbols; the exports list was not applied"
+                  continue
+                fi
+                echo "✅ $export_count exported symbols"
               fi
 
               # Linux binaries were stripped by the shim's llvm-objcopy

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -252,10 +252,12 @@ jobs:
           # All Linux targets link via the direct zig invocation (the only
           # Linux link flow; the clang shim hard-errors if a Linux link
           # reaches it). The extra linux-x64 variants, spread across the
-          # groups to keep the four streams balanced at 4/3/2/3:
+          # groups to keep the four streams balanced at 4/3/3/3:
           #   linux-x64-selftest - net10.0, real ICU/zlib/OpenSSL,
           #                        exercised at run time
           #   lib-linux-x64      - NativeLib=Shared library
+          #   lib-osx-arm64      - NativeLib=Shared dylib, which is where
+          #                        the exports list matters (issue #98)
           - name: Build glibc Linux targets
             shell: bash
             run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "linux-x64,linux-arm64,linux-arm,linux-x64-selftest"
@@ -264,7 +266,7 @@ jobs:
             run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "linux-musl-x64,linux-musl-arm64,linux-musl-arm"
           - name: Build macOS targets
             shell: bash
-            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "osx-x64,osx-arm64"
+            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "osx-x64,osx-arm64,lib-osx-arm64"
           - name: Build Windows targets and linux shared library
             shell: bash
             run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "win-x64,win-arm64,lib-linux-x64"
@@ -310,10 +312,11 @@ jobs:
           - runner: macos-15-intel
             runner-name: macos-x64
             test-targets: "osx-x64"
-          # Test macOS binaries on macOS ARM64
+          # Test macOS binaries on macOS ARM64. lib-osx-arm64 covers the
+          # shared library (loaded via ctypes) and its export surface.
           - runner: depot-macos-latest
             runner-name: macos-arm64
-            test-targets: "osx-arm64"
+            test-targets: "osx-arm64,lib-osx-arm64"
           # Test Windows x64 binaries on Windows x64. The windows-host builds
           # are MSVC-linked (package inert there); the others are zig-linked
           # by the shim's link personality, so this is where the MinGW-glued
@@ -410,7 +413,8 @@ jobs:
             for target in "${TARGET_ARRAY[@]}"; do
               binary_name="Hello"
               [[ "$target" == win-* ]] && binary_name="Hello.exe"
-              [[ "$target" == lib-* ]] && binary_name="HelloLib.so"
+              [[ "$target" == lib-linux-* ]] && binary_name="HelloLib.so"
+              [[ "$target" == lib-osx-* ]] && binary_name="HelloLib.dylib"
               binary_path="binaries-$host/$target/$binary_name"
               skip_file="binaries-$host/$target/SKIPPED.txt"
               
@@ -445,7 +449,7 @@ jobs:
               # osx-x64 was signed with the CI test certificate by the build
               # job; osx-arm64 carries zig's ad-hoc linker signature. Both
               # must pass strict verification.
-              if [[ "$target" == osx-* ]]; then
+              if [[ "$target" == osx-* || "$target" == lib-osx-* ]]; then
                 echo -n "  Signature check: "
                 if ! codesign --verify --strict "$binary_path"; then
                   echo "❌ FAIL - invalid code signature"
@@ -475,14 +479,25 @@ jobs:
                 # demotes every ILC external not on the list before the link.
                 # Unapplied, ILC 8 leaves ~14k managed method symbols exported;
                 # applied, only the runtime's static-library externals (a few
-                # hundred) remain.
+                # hundred) remain - so no managed (S_P_CoreLib_*) symbol may be
+                # exported, and for the dylib the listed hello_add entry point
+                # must still be.
                 echo -n "  Exports check: "
-                export_count=$(nm -gU "$binary_path" 2>/dev/null | wc -l | tr -d ' ')
+                nm -gU "$binary_path" 2>/dev/null > /tmp/exports.txt
+                export_count=$(wc -l < /tmp/exports.txt | tr -d ' ')
                 if [ "$export_count" -ge 2000 ]; then
                   echo "❌ FAIL - $export_count exported symbols; the exports list was not applied"
                   continue
                 fi
-                echo "✅ $export_count exported symbols"
+                if grep -q "S_P_CoreLib_" /tmp/exports.txt; then
+                  echo "❌ FAIL - managed symbols are exported: $(grep -c S_P_CoreLib_ /tmp/exports.txt)"
+                  continue
+                fi
+                if [[ "$target" == lib-* ]] && ! grep -q " T _hello_add$" /tmp/exports.txt; then
+                  echo "❌ FAIL - _hello_add is not exported"
+                  continue
+                fi
+                echo "✅ $export_count exported symbols, no managed symbols"
               fi
 
               # Linux binaries were stripped by the shim's llvm-objcopy

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,17 +40,17 @@ maintenance.
    flags, GS pad and Swift overlay libs are reconstructed as MSBuild items, the
    full command line is in binlogs, and the clang shim is gone. This, plus the
    Windows link task and the managed ELF strip, retired the native shim entirely.
-5b. **Demote ILC's external symbols on macOS for net8/net9 (spike).** Issue #62's
-   dominant cost (local symbols + stabs) is fixed by link-time `-Wl,-x -Wl,-S`,
-   but symbols older ILCs emit as true externals survive: zig's linker ignores
-   `-exported_symbols_list` (and rejects `-(un)exported_symbol`), which is how
-   the standard pipeline demotes them before `strip -x`. net10+ marks them
-   hidden so output is near-parity; net8 keeps ~14k externals (~1 MB of mangled
-   names in `__LINKEDIT` for the Hello app). Spike: pre-link nlist surgery on
-   the ILC object (set `N_PEXT` on non-exported externals — zig then emits them
-   as locals and `-x` drops them; no re-sign needed since the surgery is on the
-   relocatable input, not the signed output). Keep-list: `ExportsFile` entries
-   plus `_main`.
+5b. **Demote ILC's external symbols on macOS for net8/net9. ✅ Done (#98).**
+   Issue #62's dominant cost (local symbols + stabs) is fixed by link-time
+   `-Wl,-x -Wl,-S`, but symbols older ILCs emit as true externals survived:
+   zig's linker ignores `-exported_symbols_list` (and rejects
+   `-(un)exported_symbol`), which is how the standard pipeline demotes them
+   before `strip -x`. `AotAnywherePatchAppleObject` now applies the exports
+   list itself — pre-link nlist surgery on the ILC object setting `N_PEXT` on
+   every external not in `ExportsFile`; zig emits those hidden and `-x` drops
+   them. No re-sign needed since the surgery is on the relocatable input. The
+   runtime's static libraries are not rewritten, so their few hundred externals
+   still show in `nm -gU`.
 
 ## Tier 3 — Architecture / tech debt
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -24,6 +24,11 @@ directly by Zig or in managed code:
   MSBuild task (Zig cannot strip ELF), which implements the minimal ELF surgery
   `llvm-objcopy` would do (strip non-alloc sections, `--only-keep-debug` sidecar,
   `.gnu_debuglink`).
+- **macOS object fixups** are done by the `AotAnywherePatchAppleObject` MSBuild
+  task on the ILC object right before the link: it clears the debug attribute
+  zig would otherwise drop the managed GC-info table for, and applies the SDK's
+  exported-symbols list (which zig's linker ignores) by marking every symbol
+  not on it private-external.
 
 The ILC SDK's linker/objcopy probes (`command -v`) that would otherwise require
 clang/llvm-objcopy on `PATH` are simply pointed at the restored Zig, which

--- a/docs/cross-platform-validation.md
+++ b/docs/cross-platform-validation.md
@@ -42,7 +42,10 @@ invocation, the only Linux link flow — every host also publishes decorated
 `linux-x64` variants (see `build-targets.sh`): `lib-linux-x64` (a
 `NativeLib=Shared` library, loaded and called via python ctypes during
 validation) and `linux-x64-selftest` (a net10.0 build exercising real
-ICU, zlib and OpenSSL at run time via `--selftest`).
+ICU, zlib and OpenSSL at run time via `--selftest`), plus `lib-osx-arm64`,
+the same shared library as a dylib, which additionally checks that the
+exports list was applied to the zig macho link (only `hello_add` and the
+runtime's own externals exported, no managed method symbols).
 
 ### 2. Build Process
 For each host-target combination:

--- a/docs/macos-targets.md
+++ b/docs/macos-targets.md
@@ -27,10 +27,16 @@ Things to know:
   and reject zig-linked binaries anyway. That also means no `.dSYM` sidecar is
   produced; publish with `/p:StripSymbols=false` to keep the symbols in the
   binary instead. (Native AOT stack traces don't need either — they come from
-  ILC's own metadata.) Older ILCs emit many method symbols as externals, which
-  link-time stripping cannot remove, so binaries get closer to the standard
-  pipeline's size the newer the target framework: on .NET 10 they are within a
-  few percent, on .NET 8 noticeably larger.
+  ILC's own metadata.)
+- The SDK's exported-symbols list (`-exported_symbols_list`, which keeps a
+  `NativeLib=Shared` dylib's exports down to its `UnmanagedCallersOnly` entry
+  points and lets the strip drop the method symbols older ILCs emit as
+  externals) is ignored by zig's linker, so AotAnywhere applies it to the ILC
+  object before the link instead: every symbol not on the list is marked
+  private-external, which zig honours. The result matches the standard
+  pipeline for everything ILC emits; the few hundred externals the runtime's
+  static libraries contribute (`GlobalizationNative_*` and friends) stay
+  exported, since those libraries are not rewritten.
 - zig gives osx-arm64 binaries an ad-hoc code signature (Apple Silicon refuses
   to run entirely unsigned code); osx-x64 binaries are left unsigned. Either way
   that only covers running locally — for distribution you should sign (and if

--- a/src/DirectLink.targets
+++ b/src/DirectLink.targets
@@ -251,10 +251,23 @@
       <_MacCore Include="&quot;$(NativeObject)&quot;" />
       <_MacCore Include="&quot;$(_MacManagedEndObj)&quot;" />
       <_MacCore Include="-o &quot;$(NativeBinary)&quot;" />
-      <_MacCore Include="-exported_symbols_list &quot;$(ExportsFile)&quot;" Condition="'$(ExportsFile)' != ''" />
-      <_MacCore Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(ExportsFile)' == ''" />
       <_MacCore Include="@(LinkerArg)" />
     </ItemGroup>
+
+    <!-- The exported-symbols list is the one piece of the SDK's Apple framing
+         that is NOT on the line: zig's Mach-O linker ignores
+         -exported_symbols_list in every spelling (the bare form only draws an
+         "argument unused" warning - issue #98) and rejects -exported_symbol.
+         It is applied to the ILC object instead, before the link
+         (AotAnywherePatchAppleObject demotes every external not on the list to
+         private-external, which zig does honour). This flag mirrors when the
+         SDK would pass a list at all: always for an executable (/dev/null
+         when there is no file - export nothing), only with a file for a
+         shared library. -->
+    <PropertyGroup>
+      <_MacApplyExportsList>false</_MacApplyExportsList>
+      <_MacApplyExportsList Condition="'$(ExportsFile)' != '' or '$(OutputType)' == 'exe'">true</_MacApplyExportsList>
+    </PropertyGroup>
 
     <!-- The shim's fixups, expressed as MSBuild item transforms. -ld_classic
          is unsupported by zig's linker; -L/usr/lib/swift only makes sense on a
@@ -291,13 +304,13 @@
          after they apply. Without them, ILC's local method symbols and
          their stabs stay in __LINKEDIT and the binary is ~2-3x larger than
          the standard pipeline's (issue #62). Symbols ILC emits as true
-         externals survive - zig ignores the -exported_symbols_list that
-         would demote them. Newer ILCs mark ever more of them hidden (which
-         -x then drops): for the Hello test app net8 keeps ~14k externals,
-         net9 ~5.7k, net10 ~600, at which point the output is within ~15%
-         of the standard pipeline's. No dSYM sidecar is possible (dsymutil
-         also rejects zig output); StripSymbols=false keeps the symbols in
-         the binary instead. -->
+         externals (~14k for the net8 Hello app, ~5.7k net9, ~600 net10)
+         would survive -x, since zig ignores the -exported_symbols_list that
+         demotes them in the standard pipeline; the exports list is applied
+         to the ILC object instead (see _MacApplyExportsList), after which
+         -x drops them too. No dSYM sidecar is possible (dsymutil also
+         rejects zig output); StripSymbols=false keeps the symbols in the
+         binary instead. -->
     <ItemGroup Condition="'$(StripSymbols)' == 'true'">
       <_MacStrip Include="-Wl,-x" />
       <_MacStrip Include="-Wl,-S" />
@@ -332,12 +345,17 @@
 
     <Message Importance="high" Text="AotAnywhere: linking $(NativeBinary) with zig directly (macOS $([MSBuild]::ValueOrDefault('$(_AotAnywhereMacHostLink)', 'false').Replace('true','native').Replace('false','cross')))" />
 
-    <!-- Clear S_ATTR_DEBUG on .dotnet_eh_table in the ILC object: zig's
-         linker drops debug-attributed sections, and losing the managed
-         GC-info table makes the first garbage collection read garbage and
-         crash. In-place and idempotent (rewrites only when the bit is set),
-         so incremental timestamps stay stable. -->
-    <AotAnywherePatchAppleObject ObjectFile="$(NativeObject)" />
+    <!-- Prepare the ILC object for zig: clear S_ATTR_DEBUG on
+         .dotnet_eh_table (zig's linker drops debug-attributed sections, and
+         losing the managed GC-info table makes the first garbage collection
+         read garbage and crash), and apply the exports list by demoting the
+         externals not on it to private-external (zig ignores
+         -exported_symbols_list; see _AotAnywhereComputeMacLinkArgs). In-place
+         and idempotent (rewrites only when a bit actually changes), so
+         incremental timestamps stay stable. -->
+    <AotAnywherePatchAppleObject ObjectFile="$(NativeObject)"
+                                 ExportsFile="$(ExportsFile)"
+                                 ApplyExportsList="$(_MacApplyExportsList)" />
 
     <!-- Pre-assemble the managed-code bookends (directive-only .s, so this is
          instant). They cannot ride the link line as sources: zig cc appends

--- a/src/tasks/AotAnywhere.Tasks/AotAnywherePatchAppleObject.cs
+++ b/src/tasks/AotAnywhere.Tasks/AotAnywherePatchAppleObject.cs
@@ -3,27 +3,45 @@ using MSBuildTask = Microsoft.Build.Utilities.Task;
 
 namespace AotAnywhere.Tasks;
 
-/// Prepares the ILC relocatable object for a zig macOS link: clears
-/// S_ATTR_DEBUG on __DATA,.dotnet_eh_table so zig's Mach-O linker does not
-/// drop the managed GC-info table from the binary (which would make the
-/// first garbage collection crash - see MachoEhTablePatcher).
+/// Prepares the ILC relocatable object for a zig macOS link:
+///
+///  - clears S_ATTR_DEBUG on __DATA,.dotnet_eh_table so zig's Mach-O linker
+///    does not drop the managed GC-info table from the binary (which would
+///    make the first garbage collection crash - see MachoEhTablePatcher);
+///  - when ApplyExportsList is set, demotes every defined external symbol not
+///    named in ExportsFile to private-external, which is how the SDK's
+///    `-exported_symbols_list` (ignored by zig) takes effect - see
+///    MachoExportsDemoter. An empty ExportsFile keeps nothing, matching the
+///    `-exported_symbols_list /dev/null` the SDK passes for executables.
 ///
 /// Runs in place on $(NativeObject), immediately before the link. Idempotent:
-/// the file is rewritten only when the attribute is actually set, so
-/// incremental builds see a stable timestamp.
+/// the file is rewritten only when something actually changed, so incremental
+/// builds see a stable timestamp. (ILC regenerates the object and the exports
+/// file together, so a stale demotion cannot outlive its list.)
 public sealed class AotAnywherePatchAppleObject : MSBuildTask
 {
     /// The ILC-produced Mach-O relocatable object ($(NativeObject)).
     [Required] public string ObjectFile { get; set; } = "";
+
+    /// The SDK's $(ExportsFile): one exported symbol per line, as ILC writes
+    /// it. Empty means export nothing (when ApplyExportsList is set).
+    public string ExportsFile { get; set; } = "";
+
+    /// Whether to apply the exports list at all. Off for a shared library
+    /// with no ExportsFile, where the SDK passes no list and everything
+    /// stays exported.
+    public bool ApplyExportsList { get; set; }
 
     public override bool Execute()
     {
         try
         {
             var data = File.ReadAllBytes(ObjectFile);
+            var changed = false;
+
             if (MachoEhTablePatcher.ClearDebugAttr(data, ".dotnet_eh_table"))
             {
-                File.WriteAllBytes(ObjectFile, data);
+                changed = true;
                 Log.LogMessage(MessageImportance.Low,
                     $"AotAnywhere: cleared S_ATTR_DEBUG on .dotnet_eh_table in '{ObjectFile}'.");
             }
@@ -32,6 +50,29 @@ public sealed class AotAnywherePatchAppleObject : MSBuildTask
                 Log.LogMessage(MessageImportance.Low,
                     $"AotAnywhere: no .dotnet_eh_table debug attribute to clear in '{ObjectFile}'.");
             }
+
+            if (ApplyExportsList)
+            {
+                var keep = ExportsFile.Length == 0
+                    ? new HashSet<string>(StringComparer.Ordinal)
+                    : MachoExportsDemoter.ParseExportsList(File.ReadAllLines(ExportsFile));
+                var demoted = MachoExportsDemoter.Demote(data, keep);
+                if (demoted > 0)
+                {
+                    changed = true;
+                    Log.LogMessage(MessageImportance.Low,
+                        $"AotAnywhere: demoted {demoted} external symbols in '{ObjectFile}' to private-external " +
+                        $"({keep.Count} kept exported per '{(ExportsFile.Length == 0 ? "/dev/null" : ExportsFile)}').");
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low,
+                        $"AotAnywhere: no external symbols to demote in '{ObjectFile}'.");
+                }
+            }
+
+            if (changed)
+                File.WriteAllBytes(ObjectFile, data);
             return true;
         }
         catch (Exception ex) when (ex is IOException or MachoFormatException)

--- a/src/tasks/AotAnywhere.Tasks/MachoEhTablePatcher.cs
+++ b/src/tasks/AotAnywhere.Tasks/MachoEhTablePatcher.cs
@@ -1,10 +1,5 @@
 namespace AotAnywhere.Tasks;
 
-public sealed class MachoFormatException : Exception
-{
-    public MachoFormatException(string message) : base(message) { }
-}
-
 /// Pure Mach-O surgery for the ILC relocatable object on Apple targets:
 /// clears S_ATTR_DEBUG on the __DATA,.dotnet_eh_table section header.
 ///
@@ -19,9 +14,6 @@ public sealed class MachoFormatException : Exception
 /// treat the section as the ordinary __DATA payload it really is.
 public static class MachoEhTablePatcher
 {
-    const uint MhMagic64 = 0xFEEDFACF;
-    const uint MhObject = 0x1;
-    const uint LcSegment64 = 0x19;
     const uint SAttrDebug = 0x02000000;
 
     /// Clears S_ATTR_DEBUG on `sectionName` in a 64-bit little-endian Mach-O
@@ -30,63 +22,40 @@ public static class MachoEhTablePatcher
     /// Throws MachoFormatException when `data` is not the MH_OBJECT expected.
     public static bool ClearDebugAttr(byte[] data, string sectionName)
     {
-        if (data.Length < 32)
-            throw new MachoFormatException("truncated Mach-O header");
-
-        var magic = Rd32(data, 0);
-        if (magic != MhMagic64)
-            throw new MachoFormatException($"not a 64-bit little-endian Mach-O (magic 0x{magic:x8})");
-
-        var filetype = Rd32(data, 12);
-        if (filetype != MhObject)
-            throw new MachoFormatException($"not a relocatable object (filetype {filetype})");
-
-        var ncmds = Rd32(data, 16);
         var changed = false;
 
-        long offset = 32;
-        for (uint i = 0; i < ncmds; i++)
+        MachoObject.ForEachLoadCommand(data, (cmd, offset, cmdsize) =>
         {
-            if (offset + 8 > data.Length)
-                throw new MachoFormatException("truncated load commands");
+            if (cmd != MachoObject.LcSegment64)
+                return;
 
-            var cmd = Rd32(data, (int)offset);
-            var cmdsize = Rd32(data, (int)offset + 4);
-            if (cmdsize < 8 || offset + cmdsize > data.Length)
-                throw new MachoFormatException("bad load command size");
+            // segment_command_64: cmd cmdsize segname[16] vmaddr vmsize
+            // fileoff filesize maxprot initprot nsects flags; section
+            // headers (80 bytes each) follow at +72.
+            if (cmdsize < 72)
+                throw new MachoFormatException("truncated segment command");
 
-            if (cmd == LcSegment64)
+            var nsects = MachoObject.Rd32(data, offset + 8 + 56);
+            if (72 + (long)nsects * 80 > cmdsize)
+                throw new MachoFormatException("section headers past segment command");
+
+            for (uint s = 0; s < nsects; s++)
             {
-                // segment_command_64: cmd cmdsize segname[16] vmaddr vmsize
-                // fileoff filesize maxprot initprot nsects flags; section
-                // headers (80 bytes each) follow at +72.
-                if (cmdsize < 72)
-                    throw new MachoFormatException("truncated segment command");
+                var so = (int)(offset + 72 + (long)s * 80);
+                if (!SectionNameEquals(data, so, sectionName))
+                    continue;
 
-                var nsects = Rd32(data, (int)offset + 8 + 56);
-                if (72 + (long)nsects * 80 > cmdsize)
-                    throw new MachoFormatException("section headers past segment command");
-
-                for (uint s = 0; s < nsects; s++)
+                // section_64 flags live at +64 (sectname[16] segname[16]
+                // addr(8) size(8) offset(4) align(4) reloff(4) nreloc(4)).
+                var flagsOffset = so + 64;
+                var flags = MachoObject.Rd32(data, flagsOffset);
+                if ((flags & SAttrDebug) != 0)
                 {
-                    var so = (int)(offset + 72 + (long)s * 80);
-                    if (!SectionNameEquals(data, so, sectionName))
-                        continue;
-
-                    // section_64 flags live at +64 (sectname[16] segname[16]
-                    // addr(8) size(8) offset(4) align(4) reloff(4) nreloc(4)).
-                    var flagsOffset = so + 64;
-                    var flags = Rd32(data, flagsOffset);
-                    if ((flags & SAttrDebug) != 0)
-                    {
-                        Wr32(data, flagsOffset, flags & ~SAttrDebug);
-                        changed = true;
-                    }
+                    MachoObject.Wr32(data, flagsOffset, flags & ~SAttrDebug);
+                    changed = true;
                 }
             }
-
-            offset += cmdsize;
-        }
+        });
 
         return changed;
     }
@@ -102,15 +71,5 @@ public static class MachoEhTablePatcher
                 return false;
         }
         return true;
-    }
-
-    static uint Rd32(byte[] d, int o) => (uint)(d[o] | (d[o + 1] << 8) | (d[o + 2] << 16) | (d[o + 3] << 24));
-
-    static void Wr32(byte[] d, int o, uint v)
-    {
-        d[o] = (byte)v;
-        d[o + 1] = (byte)(v >> 8);
-        d[o + 2] = (byte)(v >> 16);
-        d[o + 3] = (byte)(v >> 24);
     }
 }

--- a/src/tasks/AotAnywhere.Tasks/MachoExportsDemoter.cs
+++ b/src/tasks/AotAnywhere.Tasks/MachoExportsDemoter.cs
@@ -1,0 +1,111 @@
+using System.Text;
+
+namespace AotAnywhere.Tasks;
+
+/// Pure Mach-O surgery for the ILC relocatable object on Apple targets:
+/// applies the SDK's exported-symbols list by demoting every defined external
+/// symbol that is not on it to private-external (N_PEXT).
+///
+/// The standard pipeline hands ld64 `-exported_symbols_list <file>` (or
+/// `/dev/null` for an executable with no list), which is what keeps a
+/// NativeLib=Shared dylib's export trie down to its UnmanagedCallersOnly
+/// entry points and lets `strip -x` drop the thousands of method symbols
+/// older ILCs emit as externals. zig's Mach-O linker accepts the option in
+/// every spelling (bare, -Wl,) and honours none of them - the bare form only
+/// earns an "argument unused" warning (issue #98) - and rejects
+/// -(un)exported_symbol outright. What it does honour is the N_PEXT bit on an
+/// input symbol: a private external resolves within the link like any global
+/// but is emitted hidden, so it never reaches the export trie and ld64's -x
+/// (which the link line already passes for StripSymbols) drops it from the
+/// symbol table. Setting that bit on the ILC object before the link is
+/// therefore equivalent to the exports list for everything ILC emits. (The
+/// runtime's static libraries are not rewritten, so the few hundred externals
+/// they contribute stay exported; ld64 would have demoted those too.)
+///
+/// The surgery is on the relocatable input, so no re-signing of the output is
+/// involved, and only a bit is set - re-running is a no-op.
+public static class MachoExportsDemoter
+{
+    const byte NStab = 0xe0;
+    const byte NPext = 0x10;
+    const byte NType = 0x0e;
+    const byte NExt = 0x01;
+    const byte NSect = 0x0e;
+
+    /// Sets N_PEXT on every defined (N_SECT) external symbol in the 64-bit
+    /// little-endian Mach-O relocatable object in `data`, in place, except
+    /// the names in `keep`. Undefined symbols, locals, stabs and symbols that
+    /// are already private-external are left alone. Returns the number of
+    /// symbols demoted (0 when there was nothing to do, e.g. on a re-run).
+    /// Throws MachoFormatException when `data` is not the MH_OBJECT expected.
+    public static int Demote(byte[] data, ISet<string> keep)
+    {
+        var demoted = 0;
+
+        MachoObject.ForEachLoadCommand(data, (cmd, offset, cmdsize) =>
+        {
+            if (cmd != MachoObject.LcSymtab)
+                return;
+
+            // symtab_command: cmd cmdsize symoff nsyms stroff strsize.
+            if (cmdsize < 24)
+                throw new MachoFormatException("truncated symtab command");
+
+            var symoff = MachoObject.Rd32(data, offset + 8);
+            var nsyms = MachoObject.Rd32(data, offset + 12);
+            var stroff = MachoObject.Rd32(data, offset + 16);
+            var strsize = MachoObject.Rd32(data, offset + 20);
+            if (symoff + (long)nsyms * 16 > data.Length)
+                throw new MachoFormatException("symbol table past end of file");
+            if (stroff + (long)strsize > data.Length)
+                throw new MachoFormatException("string table past end of file");
+
+            for (uint i = 0; i < nsyms; i++)
+            {
+                // nlist_64: n_strx(4) n_type(1) n_sect(1) n_desc(2) n_value(8)
+                var so = (int)(symoff + (long)i * 16);
+                var nType = data[so + 4];
+                if ((nType & NStab) != 0 || (nType & NExt) == 0 ||
+                    (nType & NType) != NSect || (nType & NPext) != 0)
+                    continue;
+
+                var name = ReadName(data, stroff, strsize, MachoObject.Rd32(data, so));
+                if (keep.Contains(name))
+                    continue;
+
+                data[so + 4] = (byte)(nType | NPext);
+                demoted++;
+            }
+        });
+
+        return demoted;
+    }
+
+    /// Parses an ld64 exported-symbols list: one symbol per line, blank lines
+    /// and `#` comments ignored. ILC writes plain names (`_hello_add`), which
+    /// is all that is supported - no ld64 wildcards.
+    public static HashSet<string> ParseExportsList(IEnumerable<string> lines)
+    {
+        var keep = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in lines)
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line[0] == '#')
+                continue;
+            keep.Add(line);
+        }
+        return keep;
+    }
+
+    static string ReadName(byte[] data, uint stroff, uint strsize, uint strx)
+    {
+        if (strx >= strsize)
+            throw new MachoFormatException("symbol name past end of string table");
+        var start = (int)(stroff + strx);
+        var end = start;
+        var limit = (int)(stroff + strsize);
+        while (end < limit && data[end] != 0)
+            end++;
+        return Encoding.UTF8.GetString(data, start, end - start);
+    }
+}

--- a/src/tasks/AotAnywhere.Tasks/MachoObject.cs
+++ b/src/tasks/AotAnywhere.Tasks/MachoObject.cs
@@ -1,0 +1,64 @@
+namespace AotAnywhere.Tasks;
+
+public sealed class MachoFormatException : Exception
+{
+    public MachoFormatException(string message) : base(message) { }
+}
+
+/// Shared plumbing for the in-place surgeries on the ILC relocatable object
+/// (MachoEhTablePatcher, MachoExportsDemoter): header validation, the load
+/// command walk, and little-endian field access.
+internal static class MachoObject
+{
+    const uint MhMagic64 = 0xFEEDFACF;
+    const uint MhObject = 0x1;
+
+    public const uint LcSymtab = 0x2;
+    public const uint LcSegment64 = 0x19;
+
+    public delegate void LoadCommandVisitor(uint cmd, int offset, uint cmdsize);
+
+    /// Validates that `data` is a 64-bit little-endian MH_OBJECT and calls
+    /// `visit` for each load command with its type, file offset and size.
+    /// Throws MachoFormatException on anything else.
+    public static void ForEachLoadCommand(byte[] data, LoadCommandVisitor visit)
+    {
+        if (data.Length < 32)
+            throw new MachoFormatException("truncated Mach-O header");
+
+        var magic = Rd32(data, 0);
+        if (magic != MhMagic64)
+            throw new MachoFormatException($"not a 64-bit little-endian Mach-O (magic 0x{magic:x8})");
+
+        var filetype = Rd32(data, 12);
+        if (filetype != MhObject)
+            throw new MachoFormatException($"not a relocatable object (filetype {filetype})");
+
+        var ncmds = Rd32(data, 16);
+
+        long offset = 32;
+        for (uint i = 0; i < ncmds; i++)
+        {
+            if (offset + 8 > data.Length)
+                throw new MachoFormatException("truncated load commands");
+
+            var cmd = Rd32(data, (int)offset);
+            var cmdsize = Rd32(data, (int)offset + 4);
+            if (cmdsize < 8 || offset + cmdsize > data.Length)
+                throw new MachoFormatException("bad load command size");
+
+            visit(cmd, (int)offset, cmdsize);
+            offset += cmdsize;
+        }
+    }
+
+    public static uint Rd32(byte[] d, int o) => (uint)(d[o] | (d[o + 1] << 8) | (d[o + 2] << 16) | (d[o + 3] << 24));
+
+    public static void Wr32(byte[] d, int o, uint v)
+    {
+        d[o] = (byte)v;
+        d[o + 1] = (byte)(v >> 8);
+        d[o + 2] = (byte)(v >> 16);
+        d[o + 3] = (byte)(v >> 24);
+    }
+}

--- a/tests/AotAnywhere.MSBuild.Tests/MacLinkArgsTests.cs
+++ b/tests/AotAnywhere.MSBuild.Tests/MacLinkArgsTests.cs
@@ -10,8 +10,8 @@ namespace AotAnywhere.MSBuild.Tests;
 // -Wl,--gc-sections / --discard-all onto the net8 macho link.
 public class MacLinkArgsTests
 {
-    static string[] Compute(string linkerArgs, string sysroot = "/opt/applesdk",
-        string? stripSymbols = null)
+    static RunResult Run(string linkerArgs, string sysroot = "/opt/applesdk",
+        string? stripSymbols = null, string exportsFile = "", string outputType = "exe")
     {
         var props = new Dictionary<string, string>
         {
@@ -19,8 +19,8 @@ public class MacLinkArgsTests
             ["_MacSysroot"] = sysroot,
             ["NativeObject"] = "/obj/Hello.o",
             ["NativeBinary"] = "/bin/Hello",
-            ["ExportsFile"] = "",
-            ["OutputType"] = "exe",
+            ["ExportsFile"] = exportsFile,
+            ["OutputType"] = outputType,
             ["TestLinkerArgs"] = linkerArgs,
         };
         if (stripSymbols is not null)
@@ -28,8 +28,12 @@ public class MacLinkArgsTests
         var result = Harness.Run("_AotAnywhereComputeMacLinkArgs", props);
         if (!result.Success)
             throw new Exception($"_AotAnywhereComputeMacLinkArgs failed: {result.ErrorText}");
-        return result.Items("_MacLinkArg");
+        return result;
     }
+
+    static string[] Compute(string linkerArgs, string sysroot = "/opt/applesdk",
+        string? stripSymbols = null, string exportsFile = "", string outputType = "exe") =>
+        Run(linkerArgs, sysroot, stripSymbols, exportsFile, outputType).Items("_MacLinkArg");
 
     [Test]
     public async Task NeverEmitsGnuSectionFlags()
@@ -120,6 +124,37 @@ public class MacLinkArgsTests
         await Assert.That(start).IsGreaterThan(-1);
         await Assert.That(obj).IsEqualTo(start + 1);
         await Assert.That(end).IsEqualTo(obj + 1);
+    }
+
+    // zig's Mach-O linker ignores -exported_symbols_list in every spelling
+    // (the bare form the SDK uses draws an "argument unused" warning - issue
+    // #98), so the exports list never rides the link line; it is applied to
+    // the ILC object by AotAnywherePatchAppleObject instead, gated by
+    // _MacApplyExportsList, which mirrors when the SDK would pass a list:
+    // always for an executable (/dev/null without a file), only with a file
+    // for a shared library.
+    [Test]
+    public async Task NeverPassesExportedSymbolsList()
+    {
+        foreach (var args in new[]
+                 {
+                     Compute("--target=aarch64-macos"),
+                     Compute("--target=aarch64-macos", exportsFile: "/obj/Hello.exports"),
+                     Compute("--target=aarch64-macos", exportsFile: "/obj/Hello.exports", outputType: "Library"),
+                 })
+        {
+            await Assert.That(args.Any(a => a.Contains("exported_symbols_list"))).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task AppliesExportsListLikeTheSdkWould()
+    {
+        await Assert.That(Run("--target=aarch64-macos").Prop("_MacApplyExportsList")).IsEqualTo("true");
+        await Assert.That(Run("--target=aarch64-macos", outputType: "Exe").Prop("_MacApplyExportsList")).IsEqualTo("true");
+        await Assert.That(Run("--target=aarch64-macos", exportsFile: "/obj/Hello.exports").Prop("_MacApplyExportsList")).IsEqualTo("true");
+        await Assert.That(Run("--target=aarch64-macos", exportsFile: "/obj/HelloLib.exports", outputType: "Library").Prop("_MacApplyExportsList")).IsEqualTo("true");
+        await Assert.That(Run("--target=aarch64-macos", outputType: "Library").Prop("_MacApplyExportsList")).IsEqualTo("false");
     }
 
     [Test]

--- a/tests/AotAnywhere.MSBuild.Tests/MachoExportsDemoterTests.cs
+++ b/tests/AotAnywhere.MSBuild.Tests/MachoExportsDemoterTests.cs
@@ -1,0 +1,179 @@
+using AotAnywhere.Tasks;
+
+namespace AotAnywhere.MSBuild.Tests;
+
+// MachoExportsDemoter applies the SDK's exported-symbols list to the ILC
+// object before a zig macOS link: zig ignores -exported_symbols_list (issue
+// #98), but honours N_PEXT on an input symbol, so every defined external not
+// on the list gets that bit set. These tests run the pure surgery against
+// synthetic MH_OBJECT images with a hand-built LC_SYMTAB.
+public class MachoExportsDemoterTests
+{
+    const byte NExt = 0x01;
+    const byte NPext = 0x10;
+    const byte NSect = 0x0e;
+    const byte NUndf = 0x00;
+    const byte NAbs = 0x02;
+    const byte NFun = 0x24;   // a stab (N_STAB bits set)
+
+    record Sym(string Name, byte Type);
+
+    // MH_OBJECT with a single LC_SYMTAB; symbols and the string table follow
+    // the load commands.
+    static byte[] BuildObject(params Sym[] syms)
+    {
+        var strtab = new List<byte> { 0 }; // index 0 is the empty name
+        var strx = new uint[syms.Length];
+        for (var i = 0; i < syms.Length; i++)
+        {
+            strx[i] = (uint)strtab.Count;
+            strtab.AddRange(System.Text.Encoding.ASCII.GetBytes(syms[i].Name));
+            strtab.Add(0);
+        }
+
+        var symoff = 32 + 24;
+        var stroff = symoff + syms.Length * 16;
+        var data = new byte[stroff + strtab.Count];
+        Wr32(data, 0, 0xFEEDFACF);        // MH_MAGIC_64
+        Wr32(data, 4, 0x0100000C);        // cputype arm64
+        Wr32(data, 12, 0x1);              // MH_OBJECT
+        Wr32(data, 16, 1);                // ncmds
+        Wr32(data, 20, 24);               // sizeofcmds
+        Wr32(data, 32, 0x2);              // LC_SYMTAB
+        Wr32(data, 36, 24);
+        Wr32(data, 40, (uint)symoff);
+        Wr32(data, 44, (uint)syms.Length);
+        Wr32(data, 48, (uint)stroff);
+        Wr32(data, 52, (uint)strtab.Count);
+        for (var i = 0; i < syms.Length; i++)
+        {
+            var so = symoff + i * 16;
+            Wr32(data, so, strx[i]);
+            data[so + 4] = syms[i].Type;
+            data[so + 5] = 1;             // n_sect
+        }
+        strtab.CopyTo(data, stroff);
+        return data;
+    }
+
+    static byte TypeOf(byte[] data, int index) => data[32 + 24 + index * 16 + 4];
+
+    static void Wr32(byte[] d, int o, uint v)
+    {
+        d[o] = (byte)v;
+        d[o + 1] = (byte)(v >> 8);
+        d[o + 2] = (byte)(v >> 16);
+        d[o + 3] = (byte)(v >> 24);
+    }
+
+    static HashSet<string> Keep(params string[] names) => new(names, StringComparer.Ordinal);
+
+    [Test]
+    public async Task DemotesExternalsNotOnTheList()
+    {
+        var data = BuildObject(new Sym("_hello_add", NSect | NExt), new Sym("_S_P_CoreLib_Foo", NSect | NExt));
+        var demoted = MachoExportsDemoter.Demote(data, Keep("_hello_add"));
+        await Assert.That(demoted).IsEqualTo(1);
+        await Assert.That(TypeOf(data, 0)).IsEqualTo((byte)(NSect | NExt));
+        await Assert.That(TypeOf(data, 1)).IsEqualTo((byte)(NSect | NExt | NPext));
+    }
+
+    [Test]
+    public async Task EmptyListDemotesEverything()
+    {
+        // the executable case: -exported_symbols_list /dev/null
+        var data = BuildObject(new Sym("_a", NSect | NExt), new Sym("_b", NSect | NExt));
+        var demoted = MachoExportsDemoter.Demote(data, Keep());
+        await Assert.That(demoted).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task LeavesUndefinedLocalsStabsAndAbsoluteAlone()
+    {
+        var data = BuildObject(
+            new Sym("_undefined", NUndf | NExt),
+            new Sym("ltmp0", NSect),
+            new Sym("_stab", NFun),
+            new Sym("_abs", NAbs | NExt));
+        var demoted = MachoExportsDemoter.Demote(data, Keep());
+        await Assert.That(demoted).IsEqualTo(0);
+        await Assert.That(TypeOf(data, 0)).IsEqualTo((byte)(NUndf | NExt));
+        await Assert.That(TypeOf(data, 1)).IsEqualTo(NSect);
+        await Assert.That(TypeOf(data, 2)).IsEqualTo(NFun);
+        await Assert.That(TypeOf(data, 3)).IsEqualTo((byte)(NAbs | NExt));
+    }
+
+    [Test]
+    public async Task IdempotentOnRerun()
+    {
+        var data = BuildObject(new Sym("_a", NSect | NExt), new Sym("_keep", NSect | NExt));
+        await Assert.That(MachoExportsDemoter.Demote(data, Keep("_keep"))).IsEqualTo(1);
+        var snapshot = (byte[])data.Clone();
+        await Assert.That(MachoExportsDemoter.Demote(data, Keep("_keep"))).IsEqualTo(0);
+        await Assert.That(data).IsEquivalentTo(snapshot);
+    }
+
+    [Test]
+    public async Task AlreadyPrivateExternalIsNotCounted()
+    {
+        var data = BuildObject(new Sym("_hidden", NSect | NExt | NPext));
+        await Assert.That(MachoExportsDemoter.Demote(data, Keep())).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task KeepMatchIsExactAndCaseSensitive()
+    {
+        var data = BuildObject(new Sym("_Hello_add", NSect | NExt), new Sym("_hello_add2", NSect | NExt));
+        await Assert.That(MachoExportsDemoter.Demote(data, Keep("_hello_add"))).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ParsesIlcExportsFile()
+    {
+        var keep = MachoExportsDemoter.ParseExportsList(new[]
+        {
+            "_DotNetRuntimeDebugHeader",
+            "_hello_add",
+            "",
+            "# a comment",
+            "  _padded  ",
+        });
+        await Assert.That(keep).IsEquivalentTo(new[] { "_DotNetRuntimeDebugHeader", "_hello_add", "_padded" });
+    }
+
+    [Test]
+    public async Task RejectsNonObjectFiles()
+    {
+        var data = BuildObject(new Sym("_a", NSect | NExt));
+        Wr32(data, 12, 0x2); // MH_EXECUTE
+        await Assert.That(() => MachoExportsDemoter.Demote(data, Keep()))
+            .Throws<MachoFormatException>();
+    }
+
+    [Test]
+    public async Task RejectsSymbolTablePastEndOfFile()
+    {
+        var data = BuildObject(new Sym("_a", NSect | NExt));
+        Wr32(data, 44, 1000); // nsyms overruns the buffer
+        await Assert.That(() => MachoExportsDemoter.Demote(data, Keep()))
+            .Throws<MachoFormatException>();
+    }
+
+    [Test]
+    public async Task RejectsNamePastEndOfStringTable()
+    {
+        var data = BuildObject(new Sym("_a", NSect | NExt));
+        Wr32(data, 32 + 24, 4000); // n_strx beyond strsize
+        await Assert.That(() => MachoExportsDemoter.Demote(data, Keep()))
+            .Throws<MachoFormatException>();
+    }
+
+    [Test]
+    public async Task NoSymtabIsANoOp()
+    {
+        var data = new byte[32];
+        Wr32(data, 0, 0xFEEDFACF);
+        Wr32(data, 12, 0x1);
+        await Assert.That(MachoExportsDemoter.Demote(data, Keep())).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
Fixes #98

Turns out zig's Mach-O linker doesn't support `-exported_symbols_list` at all, the bare form just gets the "argument unused" warning and the `-Wl,` form is silently dropped, so a `NativeLib=Shared` dylib was exporting every managed method (~12k symbols on net8). zig does honour `N_PEXT` on input symbols though, so this applies the list to the ILC object before the link instead.

- `AotAnywherePatchAppleObject` gains `ExportsFile`/`ApplyExportsList` and demotes every external not on the list to private-external (new `MachoExportsDemoter`, with the load command walk pulled out into `MachoObject` so the eh-table patcher shares it)
- `-exported_symbols_list` comes off the link line, `_MacApplyExportsList` mirrors when the SDK would pass one (always for exes, only with a file for libraries)
- Because `-Wl,-x` now drops the demoted symbols too, net8 `Hello`/`HelloLib` roughly halve in size, which also ticks off ROADMAP 5b
- Docs, tests and an exports-count check in the cross-platform validation workflow

One limitation: the runtime's static libs aren't rewritten, so their few hundred externals (`GlobalizationNative_*` etc.) still show in `nm -gU`, ld64 would have demoted those too. CI has no macOS shared library target either, so the `_hello_add` export is only verified locally 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)
